### PR TITLE
Add option to configure owner/group for orchestrator config and dir

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :test do
-  gem "rake"
+  gem "rake", '< 11.0'
   gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
   gem "rspec", '> 3.4.4'
   gem "rspec-puppet"

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,6 @@ exclude_paths = [
 
 # Coverage from puppetlabs-spec-helper requires rcov which
 # doesn't work in anything since 1.8.7
-Rake::Task[:coverage].clear
 Rake::Task[:lint].clear
 
 PuppetLint.configuration.relative = true

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -148,8 +148,8 @@ class orchestrator::config inherits orchestrator {
   file { $orchestrator::config:
     path    => $config_path,
     ensure  => file,
-    owner   => 0,
-    group   => 0,
+    owner   => $owner,
+    group   => $group,
     mode    => '0644',
     content => template($orchestrator::config_template),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,8 @@ class orchestrator (
   $srv_pass          = $orchestrator::params::srv_pass,
   $metadb_host       = $orchestrator::params::metadb_host,
   $write_creds       = $orchestrator::params::write_creds,
+  $owner             = $orchestrator::params::owner,
+  $group             = $orchestrator::params::group,
 ) inherits orchestrator::params {
 
   validate_absolute_path($configs_dir)
@@ -34,15 +36,19 @@ class orchestrator (
   validate_string($service_ensure)
   validate_bool($service_manage)
   validate_string($service_name)
+  validate_string($owner)
+  validate_string($group)
 
   $config_path = "${configs_dir}${config}"
   $srv_path    = "${configs_dir}${srv_cnf}"
   $top_path    = "${configs_dir}${topology_cnf}"
 
   file { 'orch-dir':
-      path => $configs_dir,
+      path   => $configs_dir,
       ensure => directory,
-      mode => '0644',
+      owner  => $owner,
+      group  => $group,
+      mode   => '0644',
   }
   
   # Using anchor pattern based on known issue:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class orchestrator (
       group  => $group,
       mode   => '0644',
   }
-  
+
   # Using anchor pattern based on known issue:
   # http://docs.puppetlabs.com/puppet/2.7/reference/lang_containment.html#known-issues
   anchor { 'orchestrator::begin': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,4 +20,6 @@ class orchestrator::params {
   $topology_pass     = ''
   $metadb_host       = 'localhost'
   $write_creds       = true
+  $owner             = 'root'
+  $group             = 'root'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class orchestrator::params {
   $service_name      = 'orchestrator'
   $srv_cnf           = 'srv_creds.cnf'
   $srv_user          = 'orchestrator'
-  $srv_pass          = '' 
+  $srv_pass          = ''
   $topology_cnf      = 'topology_creds.cnf'
   $topology_user     = 'orchestrator'
   $topology_pass     = ''

--- a/spec/classes/orchestrator_spec.rb
+++ b/spec/classes/orchestrator_spec.rb
@@ -10,6 +10,8 @@ describe 'orchestrator' do
     it 'does contain directory /etc/orchestrator' do
       should contain_file('orch-dir').with({
         :ensure => 'directory',
+        :owner   => 'root',
+        :group   => 'root',
         :path   => '/etc/orchestrator/',
         :mode   => '0644',
       })
@@ -30,8 +32,8 @@ describe 'orchestrator' do
     it 'does contain file orchestrator.conf.json' do
       should contain_file('orchestrator.conf.json').with({
         :ensure  => 'file',
-        :owner   => '0',
-        :group   => '0',
+        :owner   => 'root',
+        :group   => 'root',
         :path    => '/etc/orchestrator/orchestrator.conf.json',
         :mode    => '0644',
       })


### PR DESCRIPTION
* Add option to configure owner/group for orchestrator config and dir
* Fixes some rake spec issues

Testing:
```
$ puppet-bundle exec rake spec
```
And locally tested this with another puppet module