### PR TITLE
Replace legacy operatingsystem fact

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,7 +3,7 @@ class orchestrator::repo inherits orchestrator {
   if $orchestrator::repo_manage {
     include packagecloud
 
-    case $::operatingsystem {
+    case $facts['os']['name'] {
       'Debian', 'Ubuntu': {
         packagecloud::repo { 'github/orchestrator':
           type => 'deb',
@@ -15,7 +15,7 @@ class orchestrator::repo inherits orchestrator {
         }
       }
       default: {
-        fail("Operating system ${::operatingsystem} was not supported for adding repo's")
+        fail("Operating system ${facts['os']['name']} was not supported for adding repo's")
       }
     }
   }


### PR DESCRIPTION
This removes the legacy `operatingsystem` fact which will no longer be available from Puppet 8. This uses the appropriate structured fact which is a drop-in replacement.